### PR TITLE
stray "aa" in German translation

### DIFF
--- a/view/de/hstrings.php
+++ b/view/de/hstrings.php
@@ -1,4 +1,4 @@
-aa<?php
+<?php
 
 if(! function_exists("string_plural_select_de")) {
 function string_plural_select_de($n){


### PR DESCRIPTION
There is a straysed "aa" in the German translation which disturbes generation of the UI.